### PR TITLE
Make file searching try both upper and lower case when searching for .app

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -375,7 +375,7 @@ void ExtractFile( FILE *in, uint64_t PartDataOffset, uint64_t FileOffset, uint64
 	fclose( out );
 }
 
-FILE* openApp (uint32_t i)
+FILE* OpenApp (uint32_t i)
 {
 	char str[1024];
 	FILE *f;
@@ -473,7 +473,7 @@ int32_t main( int32_t argc, char*argv[])
 	uint32_t CNTLen;
 	{
 		uint32_t id = bs32(tmd->Contents[0].ID);
-		FILE *f = openApp(id);
+		FILE *f = OpenApp(id);
 		if (f == NULL) {
 			printf("Failed to open content:%02X\n", id );
 			return EXIT_FAILURE;
@@ -573,7 +573,7 @@ int32_t main( int32_t argc, char*argv[])
 			if(!(fe[i].Type & 0x80))
 			{
 
-				FILE *cnt = openApp(ContFileID);
+				FILE *cnt = OpenApp(ContFileID);
 				if( cnt == NULL )
 				{
 					printf("Could not open:\"%08x\"\n", ContFileID );			


### PR DESCRIPTION
I ran into a problem with this tool on linux as my file structure looked something like this with two example files:
```
0000005d.app
0000006a.app
```
Notice the file names containing lower case variables. cdecrypt at the moment only checks for upper case. Thanks to a helper function, `openApp`, this PR will check lower case permutations in addition to what is being checked now. As an example, if we are searching for id `10` app file, all these files will be searched in the cwd: `0000000a`  `0000000a.app`  `0000000A`  `0000000A.app`.

This wasn't ever an issue with the original windows version because of course, windows is not case sensitive.